### PR TITLE
Content-type in the response header is seted using the default format.

### DIFF
--- a/src/ContentNegotiationServiceProvider.php
+++ b/src/ContentNegotiationServiceProvider.php
@@ -90,6 +90,7 @@ class ContentNegotiationServiceProvider implements ServiceProviderInterface, Boo
         foreach ($request->getAcceptableContentTypes() as $contentType) {
             // If any format is acceptable, do nothing
             if ($contentType === "*/*") {
+				$request->setRequestFormat($app["conneg.defaultFormat"]);
                 return;
             }
 


### PR DESCRIPTION
When Accept has no value, the default format is sent and the content-type in the header is seted using the default format.
Do not send the Content-type in the response header can cause problems to parse the response data.